### PR TITLE
Update for Ember CLI 2.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,21 +7,23 @@ module.exports = {
   included: function(app) {
     this._super.included.apply(this, arguments);
 
-    app.registry.add('js', {
-      name: 'ember-cli-pegjs',
-      ext: 'pegjs',
-      toTree: function(tree) {
-        if (!app.options.pegOptions)
-          app.options.pegOptions = {}
+    this.options = app.options.pegOptions || {};
+    this.options.wrapper = this.options.wrapper || function(src, parser) {
+      return 'export default ' + parser;
+    };
+  },
 
-        if (!app.options.pegOptions.wrapper) {
-          app.options.pegOptions.wrapper = function (src, parser) {
-            return 'export default ' + parser
-          }
+  setupPreprocessorRegistry: function(type, registry) {
+    if (type === 'parent') {
+      var addon = this;
+
+      registry.add('js', {
+        name: 'ember-cli-pegjs',
+        ext: 'pegjs',
+        toTree: function(tree) {
+          return peg(tree, this.options);
         }
-
-        return peg(tree, app.options.pegOptions);
-      }
-    });
+      });
+    }
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var peg = require('broccoli-pegjs');
+var Funnel = require('broccoli-funnel');
+var mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: 'ember-cli-pegjs',
@@ -21,7 +23,8 @@ module.exports = {
         name: 'ember-cli-pegjs',
         ext: 'pegjs',
         toTree: function(tree) {
-          return peg(tree, this.options);
+          var parsers = peg(new Funnel(tree, { include: [/\.pegjs$/] }), addon.options);
+          return mergeTrees([tree, parsers]);
         }
       });
     }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.0",
-    "broccoli-pegjs": "^0.0.1"
+    "broccoli-pegjs": "^1.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,18 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": ["ember-addon", "pegjs"],
+  "keywords": [
+    "ember-addon",
+    "pegjs"
+  ],
   "ember-addon": {
     "before": "ember-cli-babel"
   },
   "author": "asaf@indexia.co",
   "license": "MIT",
   "dependencies": {
+    "broccoli-funnel": "^1.0.1",
+    "broccoli-merge-trees": "^1.1.0",
     "broccoli-pegjs": "^0.0.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": ["ember-addon", "pegjs"],
+  "ember-addon": {
+    "before": "ember-cli-babel"
+  },
   "author": "asaf@indexia.co",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
As of ember-cli 2.2-beta.1, module compilation isn't being handled as a special case anymore – it's handled by Babel. This means that if `ember-cli-pegjs` executes after `ember-cli-babel`, the `export default` prefix won't be transpiled. This PR incorporates a few changes:
- adds `before: 'ember-cli-babel'` to the package definition to ensure any emitted ES6+ is transpiled
- moves the preprocessor registration into `setupPreprocessorRegistry` to ensure the addon ordering is actually respected
- funnels down to only `.pegjs` files before actually running `broccoli-pegjs`

That last change has nothing to do with the transpilation process, but was opportunistic – for large app trees, it shaves a couple seconds off of rebuild times.
